### PR TITLE
Add linke to the Faro OSS page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 <p align="left"><img src="docs/faro_logo.png" alt="Grafana Faro logo" width="400"></p>
 
-This is the root repository for the Grafana Faro project.
+This is the root repository for the [Grafana Faro project](https://grafana.com/oss/faro/).
 
 For the JavaScript Agent please go to [https://github.com/grafana/faro-web-sdk](https://github.com/grafana/faro-web-sdk).


### PR DESCRIPTION
Link to the Faro OSS page as the current README doesn't have a lot of information.