### PR TITLE
Add brands to scheme

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -153,5 +153,5 @@ If needed, we reserve the right to publicly announce removal.
 [devs]: https://github.com/grafana/faro/discussions/categories/development
 [maintainers]: https://github.com/grafana/faro/blob/master/MAINTAINERS.md
 [rough]: https://tools.ietf.org/html/rfc7282
-[team]: https://groups.google.com/g/faro-team
+[team]: https://groups.google.com/a/grafana.com/g/faro-team
 [users]: https://github.com/grafana/faro/discussions

--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -4,8 +4,10 @@
 package faro
 
 import (
+	"encoding/json"
 	"time"
 
+	"github.com/oapi-codegen/runtime"
 	ptrace "go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -42,12 +44,34 @@ type App struct {
 	Version     string `json:"version,omitempty"`
 }
 
+// Brand represents a single browser brand.
+type Brand struct {
+	Brand   string `json:"brand,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// BrandsArray defines model for BrandsArray.
+type BrandsArray = []Brand
+
+// BrandsString represents brands as a string.
+type BrandsString = string
+
 // Browser holds metadata about a client's browser.
 type Browser struct {
-	Mobile  bool   `json:"mobile,omitempty"`
-	Name    string `json:"name,omitempty"`
-	OS      string `json:"os,omitempty"`
-	Version string `json:"version,omitempty"`
+	Brands         Browser_Brands `json:"brands,omitempty"`
+	Language       string         `json:"language,omitempty"`
+	Mobile         bool           `json:"mobile,omitempty"`
+	Name           string         `json:"name,omitempty"`
+	OS             string         `json:"os,omitempty"`
+	UserAgent      string         `json:"userAgent,omitempty"`
+	Version        string         `json:"version,omitempty"`
+	ViewportHeight string         `json:"viewportHeight,omitempty"`
+	ViewportWidth  string         `json:"viewportWidth,omitempty"`
+}
+
+// Browser_Brands defines model for Browser.Brands.
+type Browser_Brands struct {
+	union json.RawMessage
 }
 
 // Event holds RUM event data.
@@ -253,3 +277,65 @@ type View struct {
 
 // SubmitPayloadJSONRequestBody defines body for SubmitPayload for application/json ContentType.
 type SubmitPayloadJSONRequestBody = Payload
+
+// AsBrandsString returns the union data inside the Browser_Brands as a BrandsString
+func (t Browser_Brands) AsBrandsString() (BrandsString, error) {
+	var body BrandsString
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromBrandsString overwrites any union data inside the Browser_Brands as the provided BrandsString
+func (t *Browser_Brands) FromBrandsString(v BrandsString) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeBrandsString performs a merge with any union data inside the Browser_Brands, using the provided BrandsString
+func (t *Browser_Brands) MergeBrandsString(v BrandsString) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsBrandsArray returns the union data inside the Browser_Brands as a BrandsArray
+func (t Browser_Brands) AsBrandsArray() (BrandsArray, error) {
+	var body BrandsArray
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromBrandsArray overwrites any union data inside the Browser_Brands as the provided BrandsArray
+func (t *Browser_Brands) FromBrandsArray(v BrandsArray) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeBrandsArray performs a merge with any union data inside the Browser_Brands, using the provided BrandsArray
+func (t *Browser_Brands) MergeBrandsArray(v BrandsArray) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t Browser_Brands) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *Browser_Brands) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}

--- a/pkg/go/go.mod
+++ b/pkg/go/go.mod
@@ -2,10 +2,15 @@ module github.com/grafana/faro/pkg/go
 
 go 1.22.3
 
-require go.opentelemetry.io/collector/pdata v1.16.0
+require (
+	github.com/oapi-codegen/runtime v1.1.1
+	go.opentelemetry.io/collector/pdata v1.16.0
+)
 
 require (
+	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/pkg/go/go.sum
+++ b/pkg/go/go.sum
@@ -1,3 +1,7 @@
+github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
+github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -6,8 +10,11 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -15,8 +22,11 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
+github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/spec/components/schemas/brand.yaml
+++ b/spec/components/schemas/brand.yaml
@@ -1,0 +1,13 @@
+components:
+  schemas:
+    Brand:
+      type: object
+      description: represents a single browser brand.
+      properties:
+        brand:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        version:
+          type: string
+          x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true

--- a/spec/components/schemas/brandsarray.yaml
+++ b/spec/components/schemas/brandsarray.yaml
@@ -1,0 +1,6 @@
+components:
+  schemas:
+    BrandsArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Brand'

--- a/spec/components/schemas/brandsstring.yaml
+++ b/spec/components/schemas/brandsstring.yaml
@@ -1,0 +1,6 @@
+components:
+  schemas:
+    BrandsString:
+      type: string
+      description: represents brands as a string.
+      x-go-type-skip-optional-pointer: true

--- a/spec/components/schemas/browser.yaml
+++ b/spec/components/schemas/browser.yaml
@@ -17,4 +17,21 @@ components:
         mobile:
           type: boolean
           x-go-type-skip-optional-pointer: true
+        userAgent:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        language:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        brands:
+          oneOf:
+            - $ref: '#/components/schemas/BrandsString'
+            - $ref: '#/components/schemas/BrandsArray'
+          x-go-type-skip-optional-pointer: true
+        viewportWidth:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        viewportHeight:
+          type: string
+          x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -105,6 +105,10 @@ components:
           type: string
           x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true
+    BrandsString:
+      type: string
+      description: represents brands as a string.
+      x-go-type-skip-optional-pointer: true
     SDK:
       type: object
       description: holds metadata about the app agent that produced the event.
@@ -122,6 +126,17 @@ components:
           x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true
       x-go-name: SDK
+    Brand:
+      type: object
+      description: represents a single browser brand.
+      properties:
+        brand:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        version:
+          type: string
+          x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true
     TimeFormat:
       type: string
       enum:
@@ -335,6 +350,23 @@ components:
         mobile:
           type: boolean
           x-go-type-skip-optional-pointer: true
+        userAgent:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        language:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        brands:
+          oneOf:
+            - $ref: '#/components/schemas/BrandsString'
+            - $ref: '#/components/schemas/BrandsArray'
+          x-go-type-skip-optional-pointer: true
+        viewportWidth:
+          type: string
+          x-go-type-skip-optional-pointer: true
+        viewportHeight:
+          type: string
+          x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true
     SDKIntegration:
       type: object
@@ -370,6 +402,10 @@ components:
         geo:
           $ref: '#/components/schemas/Geo'
       x-go-type-skip-optional-pointer: true
+    BrandsArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Brand'
     Exception:
       description: holds all the data regarding an exception.
       type: object


### PR DESCRIPTION
Add additional fields to payload.meta.browser: 

```
type Browser struct {
   ...
   UserAgent string `json:"userAgent,omitempty"`
   Language string `json:"language,omitempty"`
   Brands Browser_Brands `json:"brands,omitempty"`
   ViewportWidth string `json:"viewportWidth,omitempty"`
   ViewportHeight string `json:"viewportHeight,omitempty"`
}

type Browser_Brands {
   union json.RawMessage
}
```

initial issue https://github.com/grafana/alloy/issues/1832