### PR TITLE
chore: add serviceName property to session.overrides

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -193,6 +193,11 @@ type Meta struct {
 	View View `json:"view,omitempty"`
 }
 
+// Overrides represents session override metadata.
+type Overrides struct {
+	ServiceName string `json:"serviceName,omitempty"`
+}
+
 // Page holds metadata about the web page event originates from.
 type Page struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
@@ -231,7 +236,9 @@ type SDKIntegration struct {
 type Session struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 	ID         string            `json:"id,omitempty"`
-	Overrides  map[string]string `json:"overrides,omitempty"`
+
+	// Overrides represents session override metadata.
+	Overrides Overrides `json:"overrides,omitempty"`
 }
 
 // SpanEvent defines model for SpanEvent.

--- a/spec/components/schemas/overrides.yaml
+++ b/spec/components/schemas/overrides.yaml
@@ -1,0 +1,10 @@
+components:
+  schemas:
+    Overrides:
+      type: object
+      description: represents session override metadata.
+      properties:
+        serviceName:
+            type: string
+            x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true

--- a/spec/components/schemas/session.yaml
+++ b/spec/components/schemas/session.yaml
@@ -13,11 +13,5 @@ components:
             type: string
           x-go-type-skip-optional-pointer: true
         overrides:
-          type: object
-          serviceName:
-            type: string
-            x-go-type-skip-optional-pointer: true
-          additionalProperties:
-            type: string
-          x-go-type-skip-optional-pointer: true
+          $ref: '#/components/schemas/Overrides'
       x-go-type-skip-optional-pointer: true

--- a/spec/components/schemas/session.yaml
+++ b/spec/components/schemas/session.yaml
@@ -14,6 +14,9 @@ components:
           x-go-type-skip-optional-pointer: true
         overrides:
           type: object
+          serviceName:
+            type: string
+            x-go-type-skip-optional-pointer: true
           additionalProperties:
             type: string
           x-go-type-skip-optional-pointer: true

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -72,10 +72,7 @@ components:
             type: string
           x-go-type-skip-optional-pointer: true
         overrides:
-          type: object
-          additionalProperties:
-            type: string
-          x-go-type-skip-optional-pointer: true
+          $ref: '#/components/schemas/Overrides'
       x-go-type-skip-optional-pointer: true
     Stacktrace:
       type: object
@@ -211,6 +208,14 @@ components:
           additionalProperties:
             type: number
             format: double
+          x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true
+    Overrides:
+      type: object
+      description: represents session override metadata.
+      properties:
+        serviceName:
+          type: string
           x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true
     View:


### PR DESCRIPTION
Forgiot to add the `serviceName` property to the session.overrides object 