### PR TITLE
zizmor audit fixes

### DIFF
--- a/.github/workflows/lint_spec.yml
+++ b/.github/workflows/lint_spec.yml
@@ -7,10 +7,14 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Lint spec
-        uses: mhiew/redoc-lint-github-action@v3
+        uses: mhiew/redoc-lint-github-action@fa9aaf1f917397c43201196d45b2cb5d95dcbf86 # v3
         with:
           args: 'spec/gen/faro.gen.yaml'


### PR DESCRIPTION
zizmor audit passes now
```
➜  faro git:(main) zizmor .github/workflows/lint_spec.yml
 INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
 INFO zizmor: skipping ref-confusion: can't run without a GitHub API token
 INFO zizmor: skipping known-vulnerable-actions: can't run without a GitHub API token
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed .github/workflows/lint_spec.yml
No findings to report. Good job! (1 suppressed)
```