### PR TITLE
feat: Make `geoLocationTrackingEnabled` optional

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -211,7 +211,7 @@ type Meta struct {
 
 // Overrides represents session override metadata.
 type Overrides struct {
-	GeoLocationTrackingEnabled bool   `json:"geoLocationTrackingEnabled,omitempty"`
+	GeoLocationTrackingEnabled *bool  `json:"geoLocationTrackingEnabled,omitempty"`
 	ServiceName                string `json:"serviceName,omitempty"`
 }
 

--- a/spec/components/schemas/overrides.yaml
+++ b/spec/components/schemas/overrides.yaml
@@ -9,5 +9,5 @@ components:
             x-go-type-skip-optional-pointer: true
         geoLocationTrackingEnabled:
             type: boolean
-            x-go-type-skip-optional-pointer: true
+            x-go-type-skip-optional-pointer: false
       x-go-type-skip-optional-pointer: true

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -239,7 +239,7 @@ components:
           x-go-type-skip-optional-pointer: true
         geoLocationTrackingEnabled:
           type: boolean
-          x-go-type-skip-optional-pointer: true
+          x-go-type-skip-optional-pointer: false
       x-go-type-skip-optional-pointer: true
     View:
       type: object


### PR DESCRIPTION
Tis attribute being nullable meant that it had 2 states (true or false) but in reality there are 3.

- Explicitly set (true/false) to reflect whether the SDK wishes to be geolocated or not
- Omitted, meaning its up to the consumer to decide how to handle this case.

In order to reflect that in the model, this commit makes the field optional by making it a nullable pointer.