### PR TITLE
feat(exception): add optional fatal flag

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -214,6 +214,9 @@ type Exception struct {
 	Action  Action           `json:"action,omitempty"`
 	Context ExceptionContext `json:"context,omitempty"`
 
+	// Fatal Whether this exception caused app termination (crash, ANR, OOM). Defaults to false when not set. Web exceptions are typically non-fatal; mobile SDKs set this for native crash reports.
+	Fatal bool `json:"fatal,omitempty"`
+
 	// Fingerprint Custom grouping fingerprint
 	Fingerprint string `json:"fingerprint,omitempty"`
 

--- a/spec/components/schemas/exception.yaml
+++ b/spec/components/schemas/exception.yaml
@@ -25,6 +25,13 @@ components:
           type: string
           description: Exception class or type name
           x-go-type-skip-optional-pointer: true
+        fatal:
+          type: boolean
+          description: >
+            Whether this exception caused app termination (crash, ANR, OOM).
+            Defaults to false when not set. Web exceptions are typically
+            non-fatal; mobile SDKs set this for native crash reports.
+          x-go-type-skip-optional-pointer: true
         fingerprint:
           type: string
           description: Custom grouping fingerprint

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -264,6 +264,14 @@ components:
           type: string
           description: Exception class or type name
           x-go-type-skip-optional-pointer: true
+        fatal:
+          type: boolean
+          description: 'Whether this exception caused app termination (crash, ANR,
+            OOM). Defaults to false when not set. Web exceptions are typically non-fatal;
+            mobile SDKs set this for native crash reports.
+
+            '
+          x-go-type-skip-optional-pointer: true
         fingerprint:
           type: string
           description: Custom grouping fingerprint


### PR DESCRIPTION
## Summary

- Adds optional `fatal` boolean to the `Exception` schema to distinguish app crashes (native crashes, ANRs, OOMs) from non-fatal errors.
- Regenerates the composed spec and Go types. `x-go-type-skip-optional-pointer: true` + `omitempty` keeps `false` off the wire.
- Lets mobile SDKs stop overloading `type: "crash"` and use the real exception class in `type` alongside `fatal: true`.

Closes #69

## Follow-ups (separate PRs, out of scope here)

- `opentelemetry-collector-contrib/pkg/translator/faro`: add `faroExceptionFatal` key constant, extend `exceptionToKeyVal()` and the reverse mapping in `logs_to_faro.go` so the field survives log translation.
- React Native SDK: stop setting `type: "crash"`; set `fatal: true` with the real exception class in `type`.
- Flutter / future iOS/Android native SDKs: set `fatal: true` on crash reports.