### PR TITLE
feat(meta): add Device and OS types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ make serve              # Swagger UI for the generated spec
 - Generates models only (`generate.models: true`) — no server stubs or client code
 - Package `faro`, output `pkg/go/faro.gen.go`
 - `skip-prune: true` — keeps types that aren't directly referenced in paths
-- `name-normalizer: ToCamelCaseWithInitialisms` — so `span_id` → `SpanId`, `asn_org` → `ASNOrg`
+- `name-normalizer: ToCamelCaseWithInitialisms` — so `span_id` → `SpanID`, `asn_org` → `ASNOrg`, `build_id` → `BuildID`
 - `always-prefix-enum-values: true` — enum values get the type name as prefix
 
 ## Key schema conventions
@@ -42,6 +42,10 @@ make serve              # Swagger UI for the generated spec
 - `x-go-type-skip-optional-pointer: true` is used extensively to generate value types instead of pointers
 - `x-omitempty: false` on `TraceContext` fields ensures zero-value span/trace IDs are always serialized
 - `Browser.brands` uses `oneOf: [BrandsString, BrandsArray]` — oapi-codegen generates a union type with `As*/From*/Merge*` helpers
+
+**Mixed property-name casing.** The repo has both styles: `browser.yaml` / `app.yaml` use camelCase (`bundleId`, `userAgent`, `viewportWidth`), while `geo.yaml` / `tracecontext.yaml` use snake_case (`asn_org`, `span_id`, `trace_id`). **Prefer snake_case for new schemas that map to OTel semconv** — it mirrors OTel attribute keys on the wire and `ToCamelCaseWithInitialisms` correctly renders them in Go (`SpanID`, `ASNOrg`, `BuildID`). Match the surrounding style when extending an existing schema.
+
+**`x-go-name` is silently ignored next to `$ref`.** Per OpenAPI 3.0, siblings of `$ref` are ignored by resolvers, so `x-go-name: Foo` on a `$ref` property does nothing — the Go field name is derived from the property key via the normalizer. The only clean fix is an `allOf: [$ref: ...]` wrapper (siblings survive composition), but that can produce a wrapper type. `x-go-name` works fine on non-ref properties (see `Browser.os` string, which uses `x-go-name: OS` successfully).
 
 ## Tooling versions
 

--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -163,6 +163,27 @@ type Browser_Brands struct {
 	union json.RawMessage
 }
 
+// Device holds metadata about the device the app runs on.
+type Device struct {
+	// Brand Consumer-facing brand. E.g. Google Pixel, Samsung Galaxy.
+	Brand string `json:"brand,omitempty"`
+
+	// IsPhysical Whether this is a physical device (true) or emulator/simulator (false).
+	IsPhysical bool `json:"is_physical,omitempty"`
+
+	// Manufacturer Device manufacturer (OTel: device.manufacturer). E.g. Apple, Samsung.
+	Manufacturer string `json:"manufacturer,omitempty"`
+
+	// ModelIdentifier Machine-readable model ID (OTel: device.model.identifier). E.g. iPhone3,4, SM-G920F.
+	ModelIdentifier string `json:"model_identifier,omitempty"`
+
+	// ModelName Human-readable model name (OTel: device.model.name). E.g. iPhone 6s Plus.
+	ModelName string `json:"model_name,omitempty"`
+
+	// Type Device form factor. E.g. mobile, tablet.
+	Type string `json:"type,omitempty"`
+}
+
 // Event holds RUM event data.
 type Event struct {
 	// Action holds data about user action events. These are events that are directly related to user interactions as well as the parent action itself
@@ -317,11 +338,17 @@ type Meta struct {
 	// Browser holds metadata about a client's browser.
 	Browser Browser `json:"browser,omitempty"`
 
+	// Device holds metadata about the device the app runs on.
+	Device Device `json:"device,omitempty"`
+
 	// Geo holds metadata about a client's geo.
 	Geo Geo `json:"geo,omitempty"`
 
 	// K6 holds metadata about whether or not the run happened in a K6 browser.
 	K6 K6 `json:"k6,omitempty"`
+
+	// Os holds metadata about the operating system the app runs on.
+	Os OS `json:"os,omitempty"`
 
 	// Page holds metadata about the web page event originates from.
 	Page Page `json:"page,omitempty"`
@@ -337,6 +364,21 @@ type Meta struct {
 
 	// View holds metadata about a view.
 	View View `json:"view,omitempty"`
+}
+
+// OS holds metadata about the operating system the app runs on.
+type OS struct {
+	// BuildID OS build identifier (OTel: os.build_id). E.g. 22G91, TQ3A.230901.001.
+	BuildID string `json:"build_id,omitempty"`
+
+	// Detail Human-readable OS version detail (OTel: os.description). Richer than name+version alone.
+	Detail string `json:"detail,omitempty"`
+
+	// Name OS name (OTel: os.name). E.g. iOS, Android, Windows, macOS.
+	Name string `json:"name,omitempty"`
+
+	// Version OS version string (OTel: os.version). E.g. 18.1, 15.
+	Version string `json:"version,omitempty"`
 }
 
 // Overrides represents session override metadata.

--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -347,8 +347,8 @@ type Meta struct {
 	// K6 holds metadata about whether or not the run happened in a K6 browser.
 	K6 K6 `json:"k6,omitempty"`
 
-	// Os holds metadata about the operating system the app runs on.
-	Os OS `json:"os,omitempty"`
+	// OS Metadata about the operating system
+	OS OS `json:"os,omitempty"`
 
 	// Page holds metadata about the web page event originates from.
 	Page Page `json:"page,omitempty"`

--- a/spec/components/schemas/device.yaml
+++ b/spec/components/schemas/device.yaml
@@ -1,0 +1,31 @@
+components:
+  schemas:
+    Device:
+      type: object
+      description: holds metadata about the device the app runs on.
+      properties:
+        manufacturer:
+          type: string
+          description: "Device manufacturer (OTel: device.manufacturer). E.g. Apple, Samsung."
+          x-go-type-skip-optional-pointer: true
+        model_identifier:
+          type: string
+          description: "Machine-readable model ID (OTel: device.model.identifier). E.g. iPhone3,4, SM-G920F."
+          x-go-type-skip-optional-pointer: true
+        model_name:
+          type: string
+          description: "Human-readable model name (OTel: device.model.name). E.g. iPhone 6s Plus."
+          x-go-type-skip-optional-pointer: true
+        brand:
+          type: string
+          description: "Consumer-facing brand. E.g. Google Pixel, Samsung Galaxy."
+          x-go-type-skip-optional-pointer: true
+        is_physical:
+          type: boolean
+          description: "Whether this is a physical device (true) or emulator/simulator (false)."
+          x-go-type-skip-optional-pointer: true
+        type:
+          type: string
+          description: "Device form factor. E.g. mobile, tablet."
+          x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true

--- a/spec/components/schemas/meta.yaml
+++ b/spec/components/schemas/meta.yaml
@@ -22,6 +22,12 @@ components:
           browser:
             description: Metadata about the browser
             $ref: '#/components/schemas/Browser'
+          device:
+            description: Metadata about the device
+            $ref: '#/components/schemas/Device'
+          os:
+            description: Metadata about the operating system
+            $ref: '#/components/schemas/OS'
           k6:
             description: Metadata indicating whether the session runs in k6 browser
             $ref: '#/components/schemas/K6'

--- a/spec/components/schemas/meta.yaml
+++ b/spec/components/schemas/meta.yaml
@@ -27,7 +27,9 @@ components:
             $ref: '#/components/schemas/Device'
           os:
             description: Metadata about the operating system
-            $ref: '#/components/schemas/OS'
+            x-go-name: OS
+            allOf:
+              - $ref: '#/components/schemas/OS'
           k6:
             description: Metadata indicating whether the session runs in k6 browser
             $ref: '#/components/schemas/K6'

--- a/spec/components/schemas/os.yaml
+++ b/spec/components/schemas/os.yaml
@@ -1,0 +1,23 @@
+components:
+  schemas:
+    OS:
+      type: object
+      description: holds metadata about the operating system the app runs on.
+      properties:
+        name:
+          type: string
+          description: "OS name (OTel: os.name). E.g. iOS, Android, Windows, macOS."
+          x-go-type-skip-optional-pointer: true
+        version:
+          type: string
+          description: "OS version string (OTel: os.version). E.g. 18.1, 15."
+          x-go-type-skip-optional-pointer: true
+        build_id:
+          type: string
+          description: "OS build identifier (OTel: os.build_id). E.g. 22G91, TQ3A.230901.001."
+          x-go-type-skip-optional-pointer: true
+        detail:
+          type: string
+          description: "Human-readable OS version detail (OTel: os.description). Richer than name+version alone."
+          x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -166,6 +166,39 @@ components:
           description: Viewport height in pixels
           x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true
+    Device:
+      type: object
+      description: holds metadata about the device the app runs on.
+      properties:
+        manufacturer:
+          type: string
+          description: 'Device manufacturer (OTel: device.manufacturer). E.g. Apple,
+            Samsung.'
+          x-go-type-skip-optional-pointer: true
+        model_identifier:
+          type: string
+          description: 'Machine-readable model ID (OTel: device.model.identifier).
+            E.g. iPhone3,4, SM-G920F.'
+          x-go-type-skip-optional-pointer: true
+        model_name:
+          type: string
+          description: 'Human-readable model name (OTel: device.model.name). E.g.
+            iPhone 6s Plus.'
+          x-go-type-skip-optional-pointer: true
+        brand:
+          type: string
+          description: Consumer-facing brand. E.g. Google Pixel, Samsung Galaxy.
+          x-go-type-skip-optional-pointer: true
+        is_physical:
+          type: boolean
+          description: Whether this is a physical device (true) or emulator/simulator
+            (false).
+          x-go-type-skip-optional-pointer: true
+        type:
+          type: string
+          description: Device form factor. E.g. mobile, tablet.
+          x-go-type-skip-optional-pointer: true
+      x-go-type-skip-optional-pointer: true
     Event:
       type: object
       description: holds RUM event data.
@@ -420,6 +453,12 @@ components:
         browser:
           description: Metadata about the browser
           $ref: '#/components/schemas/Browser'
+        device:
+          description: Metadata about the device
+          $ref: '#/components/schemas/Device'
+        os:
+          description: Metadata about the operating system
+          $ref: '#/components/schemas/OS'
         k6:
           description: Metadata indicating whether the session runs in k6 browser
           $ref: '#/components/schemas/K6'
@@ -429,6 +468,28 @@ components:
         geo:
           description: Geo information (populated server-side by the receiver)
           $ref: '#/components/schemas/Geo'
+      x-go-type-skip-optional-pointer: true
+    OS:
+      type: object
+      description: holds metadata about the operating system the app runs on.
+      properties:
+        name:
+          type: string
+          description: 'OS name (OTel: os.name). E.g. iOS, Android, Windows, macOS.'
+          x-go-type-skip-optional-pointer: true
+        version:
+          type: string
+          description: 'OS version string (OTel: os.version). E.g. 18.1, 15.'
+          x-go-type-skip-optional-pointer: true
+        build_id:
+          type: string
+          description: 'OS build identifier (OTel: os.build_id). E.g. 22G91, TQ3A.230901.001.'
+          x-go-type-skip-optional-pointer: true
+        detail:
+          type: string
+          description: 'Human-readable OS version detail (OTel: os.description). Richer
+            than name+version alone.'
+          x-go-type-skip-optional-pointer: true
       x-go-type-skip-optional-pointer: true
     Overrides:
       type: object

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -458,7 +458,9 @@ components:
           $ref: '#/components/schemas/Device'
         os:
           description: Metadata about the operating system
-          $ref: '#/components/schemas/OS'
+          x-go-name: OS
+          allOf:
+            - $ref: '#/components/schemas/OS'
         k6:
           description: Metadata indicating whether the session runs in k6 browser
           $ref: '#/components/schemas/K6'


### PR DESCRIPTION
## Summary

- Adds `Device` and `OS` schemas aligned with OpenTelemetry [device](https://opentelemetry.io/docs/specs/semconv/resource/device/) and [os](https://opentelemetry.io/docs/specs/semconv/resource/os/) resource semantic conventions, plus Faro-specific fields (`brand`, `is_physical`, `type`, `detail`) already sent by mobile SDKs as flat `session.attributes` keys.
- Wires both into `Meta` as optional refs. `Browser.os` and `Browser.mobile` remain unchanged — no breaking change; SDKs can populate both during a transition.
- Regenerates the composed spec and Go types. `x-go-type-skip-optional-pointer: true` keeps Go fields as value types.

## Schema decisions

- **`device.id` intentionally omitted.** Carries PII/privacy implications and may cause App Store rejection on iOS ([OTel guidance](https://opentelemetry.io/docs/specs/semconv/registry/attributes/device/#device-id)). Privacy-preserving `app.installation.id` tracked separately in #70.
- **snake_case property names** (`model_identifier`, `build_id`, `is_physical`) to match existing `Geo` / `TraceContext` convention and OTel wire naming. `ToCamelCaseWithInitialisms` renders these as `ModelIdentifier`, `BuildID`, `IsPhysical` in Go.
- **`os.detail`** instead of `description` to avoid colliding with the OpenAPI `description` keyword; maps to OTel `os.description`.

Closes #68

## Follow-ups (separate PRs, out of scope here)

- `opentelemetry-collector-contrib/pkg/translator/faro`: add `deviceToKeyVal()` / `osToKeyVal()`, the corresponding `faro*` key constants, wire into `metaToKeyVal()`, and add the reverse mapping in `logs_to_faro.go`. Without this, the new fields are dropped at log translation.
- Mobile SDKs (React Native, Flutter): populate the structured `Device` / `OS` meta instead of flat `session.attributes` keys.
- Web SDK: deprecation notice on `Browser.os`; start populating the new `OS` meta.