### PR TITLE
feat(app): add installationId to App meta

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -100,6 +100,9 @@ type App struct {
 	// Environment Deployment environment (e.g. `production`, `staging`)
 	Environment string `json:"environment,omitempty"`
 
+	// InstallationID Per-installation identifier (OTel: app.installation.id). Identical across launches of the same installed app; resets on uninstall/reinstall. Privacy-preserving alternative to device.id. On iOS, typically sourced from identifierForVendor.
+	InstallationID string `json:"installationId,omitempty"`
+
 	// Name Application name
 	Name string `json:"name,omitempty"`
 

--- a/spec/components/schemas/app.yaml
+++ b/spec/components/schemas/app.yaml
@@ -12,6 +12,14 @@ components:
           type: string
           description: Deployment environment (e.g. `production`, `staging`)
           x-go-type-skip-optional-pointer: true
+        installationId:
+          type: string
+          description: >
+            Per-installation identifier (OTel: app.installation.id).
+            Identical across launches of the same installed app; resets on
+            uninstall/reinstall. Privacy-preserving alternative to device.id.
+            On iOS, typically sourced from identifierForVendor.
+          x-go-type-skip-optional-pointer: true
         name:
           type: string
           description: Application name

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -84,6 +84,15 @@ components:
           type: string
           description: Deployment environment (e.g. `production`, `staging`)
           x-go-type-skip-optional-pointer: true
+        installationId:
+          type: string
+          description: 'Per-installation identifier (OTel: app.installation.id). Identical
+            across launches of the same installed app; resets on uninstall/reinstall.
+            Privacy-preserving alternative to device.id. On iOS, typically sourced
+            from identifierForVendor.
+
+            '
+          x-go-type-skip-optional-pointer: true
         name:
           type: string
           description: Application name


### PR DESCRIPTION
## Summary

- Adds optional `installationId` to the `App` schema, aligned with OTel [`app.installation.id`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/app/#app-installation-id).
- Privacy-preserving alternative to `device.id` — iOS App Store friendly (typically sourced from `identifierForVendor`), identical across launches, resets on uninstall/reinstall.
- Faro Flutter SDK already computes and sends this value; the spec now gives it a structured home so other SDKs follow suit consistently.

Closes #70

## Naming note

The issue proposed `installation_id` (snake_case) but this PR uses `installationId` (camelCase) to match the surrounding `App` schema style (`bundleId`). Happy to flip to `installation_id` if you'd rather align with OTel wire naming at the cost of in-file consistency.

## Follow-ups (separate PRs, out of scope here)

- `opentelemetry-collector-contrib/pkg/translator/faro`: extend `appToKeyVal()` to serialize the new field and add the reverse mapping in `logs_to_faro.go`.
- Mobile SDKs: wire existing Flutter installation ID into the structured `App` meta; add for React Native / future iOS/Android native SDKs.