### PR TITLE
feat(k6): add testRunId to K6 meta

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -282,6 +282,9 @@ type Geo struct {
 type K6 struct {
 	// IsK6Browser `true` when running inside a k6 browser session
 	IsK6Browser bool `json:"isK6Browser,omitempty"`
+
+	// TestRunID k6 test run identifier when running inside a k6 browser session
+	TestRunID string `json:"testRunId,omitempty"`
 }
 
 // Kind defines model for Kind.

--- a/spec/components/schemas/k6.yaml
+++ b/spec/components/schemas/k6.yaml
@@ -8,4 +8,9 @@ components:
           type: boolean
           description: '`true` when running inside a k6 browser session'
           x-go-type-skip-optional-pointer: true
+        testRunId:
+          type: string
+          description: k6 test run identifier when running inside a k6 browser session
+          x-go-type-skip-optional-pointer: true
+          x-go-name: TestRunID
       x-go-type-skip-optional-pointer: true

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -356,6 +356,11 @@ components:
           type: boolean
           description: '`true` when running inside a k6 browser session'
           x-go-type-skip-optional-pointer: true
+        testRunId:
+          type: string
+          description: k6 test run identifier when running inside a k6 browser session
+          x-go-type-skip-optional-pointer: true
+          x-go-name: TestRunID
       x-go-type-skip-optional-pointer: true
     Kind:
       type: string


### PR DESCRIPTION
## Summary

- Adds optional `testRunId` to the `K6` schema. The Faro Web SDK already forwards `window.k6.testRunId` as `meta.k6.testRunId`; downstream consumers can now decode it instead of dropping it as an unknown field.
- Regenerates `pkg/go/faro.gen.go` and `spec/gen/faro.gen.yaml` via `make build-all-docker`. `omitempty` keeps absent values off the wire; `x-go-name: TestRunID` keeps the Go field's `ID` initialism.

Closes grafana/synthetic-monitoring#550. Part of grafana/synthetic-monitoring#507.

## Follow-up

- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47935 — emits `k6_testRunId` in the log body and reads it back in `pkg/translator/faro`.