### PR TITLE
feat: add git hash as a property of the app schema

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -100,6 +100,9 @@ type App struct {
 	// Environment Deployment environment (e.g. `production`, `staging`)
 	Environment string `json:"environment,omitempty"`
 
+	// GitHash Git hash of the application source code this telemetry was generated from
+	GitHash string `json:"gitHash,omitempty"`
+
 	// InstallationID Per-installation identifier (OTel: app.installation.id). Identical across launches of the same installed app; resets on uninstall/reinstall. Privacy-preserving alternative to device.id. On iOS, typically sourced from identifierForVendor.
 	InstallationID string `json:"installationId,omitempty"`
 

--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -94,7 +94,7 @@ type Action struct {
 
 // App holds metadata about the application event originates from.
 type App struct {
-	// BundleID Bundle identifier (used by mobile apps)
+	// BundleID Bundle identifier (used by apps bundled with Faro bundler plugins)
 	BundleID string `json:"bundleId,omitempty"`
 
 	// Environment Deployment environment (e.g. `production`, `staging`)

--- a/spec/components/schemas/app.yaml
+++ b/spec/components/schemas/app.yaml
@@ -6,7 +6,11 @@ components:
       properties:
         bundleId:
           type: string
-          description: Bundle identifier (used by mobile apps)
+          description: Bundle identifier (used by apps bundled with Faro bundler plugins)
+          x-go-type-skip-optional-pointer: true
+        gitHash:
+          type: string
+          description: Git hash of the application source code this telemetry was generated from
           x-go-type-skip-optional-pointer: true
         environment:
           type: string

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -79,7 +79,12 @@ components:
       properties:
         bundleId:
           type: string
-          description: Bundle identifier (used by mobile apps)
+          description: Bundle identifier (used by apps bundled with Faro bundler plugins)
+          x-go-type-skip-optional-pointer: true
+        gitHash:
+          type: string
+          description: Git hash of the application source code this telemetry was
+            generated from
           x-go-type-skip-optional-pointer: true
         environment:
           type: string


### PR DESCRIPTION
part of the suspect commits feature - adds the git hash to the app metadata so we can use it in the faro endpoint 