### PR TITLE
chore(ci): inline redocly lint, drop mhiew/redoc-lint-github-action

### DIFF
--- a/.github/workflows/lint_spec.yml
+++ b/.github/workflows/lint_spec.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Lint spec
-        uses: mhiew/redoc-lint-github-action@1b3526395495e5c1346ebb81a67813aee757e86b # v4
-        with:
-          args: 'spec/gen/faro.gen.yaml'
+        # Pinned to 1.9.0 to match what mhiew/redoc-lint-github-action@v4 ran
+        # before this step was inlined; bumps are a separate change.
+        shell: bash
+        run: npx --yes @redocly/cli@1.9.0 lint spec/gen/faro.gen.yaml


### PR DESCRIPTION
## Summary

Replace the third-party `mhiew/redoc-lint-github-action@v4` with an inline `npx @redocly/cli@1.9.0 lint`. The action's Dockerfile just installs and runs the same CLI; inlining removes the dependency on a niche third-party action and surfaces the lint tool version directly in the workflow.

Pinned to 1.9.0 to preserve current lint behavior; bumping is a separate change.

_PR description authored by Claude on Domas's behalf._