### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,69 @@
+name: codeql
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 6 * * MON'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          build-mode: ${{ matrix.build-mode }}
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          category: '/language:${{ matrix.language }}'
+
+  codeql:
+    if: ${{ !cancelled() }}
+    needs: [ analysis ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report status
+        shell: bash
+        env:
+          SCAN_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [ "${SCAN_SUCCESS}" == "true" ]
+          then
+            echo 'CodeQL analysis successful'
+          else
+            echo 'CodeQL analysis failed'
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ make build-all
 ### Go
 
 [/pkg/go](./pkg/go) contains HTTP Models in Go generated from the [OpenAPI specification](./spec/gen/faro.gen.yaml) using [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen).
+
+## Security
+
+CodeQL static analysis runs on every push, pull request, and weekly. Findings are published to the repository [code scanning alerts](https://github.com/grafana/faro/security/code-scanning) page.


### PR DESCRIPTION
## Summary

Adds a CodeQL workflow scanning Go with the `security-extended` query suite. Triggers: push to `main`, pull requests against `main`, weekly cron, and `workflow_dispatch`. Modeled on [`grafana-opentelemetry-dotnet/.github/workflows/codeql.yml`](https://github.com/grafana/grafana-opentelemetry-dotnet/blob/main/.github/workflows/codeql.yml) — least-privilege permissions, pinned action SHAs, pass/fail gate job.

The issue lists `javascript-typescript` in the matrix too, but the repo has no JS/TS source today (TS generation is commented out in the Makefile). The matrix is structured to make adding it a one-line change when TS generation is enabled.

README gets a small Security section linking to the [code scanning alerts](https://github.com/grafana/faro/security/code-scanning) page, covering the third acceptance checkbox.

Closes #99