### PR TITLE
docs(app): clarify bundleId for web and Android symbolication

### DIFF
--- a/pkg/go/faro.gen.go
+++ b/pkg/go/faro.gen.go
@@ -94,7 +94,7 @@ type Action struct {
 
 // App holds metadata about the application event originates from.
 type App struct {
-	// BundleID Bundle identifier (used by apps bundled with Faro bundler plugins)
+	// BundleID Bundle identifier (used by web apps bundled with Faro bundler plugins and mobile Android symbolication to encode build identity "{applicationId}@{versionCode}@{versionName}" (e.g. com.example.app@42@1.0.0) matching the symbols upload path and server-side R8/native retrace lookup key).
 	BundleID string `json:"bundleId,omitempty"`
 
 	// Environment Deployment environment (e.g. `production`, `staging`)

--- a/spec/components/schemas/app.yaml
+++ b/spec/components/schemas/app.yaml
@@ -6,7 +6,11 @@ components:
       properties:
         bundleId:
           type: string
-          description: Bundle identifier (used by apps bundled with Faro bundler plugins)
+          description: >
+            Bundle identifier (used by web apps bundled with Faro bundler plugins
+            and mobile Android symbolication to encode build identity
+            "{applicationId}@{versionCode}@{versionName}" (e.g. com.example.app@42@1.0.0)
+            matching the symbols upload path and server-side R8/native retrace lookup key).
           x-go-type-skip-optional-pointer: true
         gitHash:
           type: string

--- a/spec/gen/faro.gen.yaml
+++ b/spec/gen/faro.gen.yaml
@@ -79,7 +79,12 @@ components:
       properties:
         bundleId:
           type: string
-          description: Bundle identifier (used by apps bundled with Faro bundler plugins)
+          description: 'Bundle identifier (used by web apps bundled with Faro bundler
+            plugins and mobile Android symbolication to encode build identity "{applicationId}@{versionCode}@{versionName}"
+            (e.g. com.example.app@42@1.0.0) matching the symbols upload path and server-side
+            R8/native retrace lookup key).
+
+            '
           x-go-type-skip-optional-pointer: true
         gitHash:
           type: string


### PR DESCRIPTION
## Summary

Clarifies the `App.bundleId` OpenAPI description so the spec documents both
existing uses:

- **Web** — release id from Faro bundler plugins at build time
- **Mobile Android** — encoded build identity
  `{applicationId}@{versionCode}@{versionName}` (e.g. `com.example.app@42@1.0.0`),
  matching the Android symbols upload path and server-side R8/native retrace
  lookup key

No schema shape change — description only. Regenerated `spec/gen/faro.gen.yaml`
and `pkg/go/faro.gen.go` via `make build-all-docker`.

## Files changed

- `spec/components/schemas/app.yaml` — updated `bundleId` description
- `spec/gen/faro.gen.yaml` — composed spec
- `pkg/go/faro.gen.go` — generated Go comment on `App.BundleID`