### PR TITLE
Add security reporting guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,4 @@ Do not include a test plan section when opening PRs.
 - The Faro Web SDK → https://github.com/grafana/faro-web-sdk
 - The Faro ↔ OTel translator → contributed upstream to `opentelemetry-collector-contrib/pkg/translator/faro`
 - `pkg/translator/faro/` is a placeholder README only
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
